### PR TITLE
Add use case diagram

### DIFF
--- a/docs/use_cases.drawio
+++ b/docs/use_cases.drawio
@@ -1,0 +1,40 @@
+<mxfile host="app.diagrams.net">
+  <diagram name="Use Cases">
+    <mxGraphModel dx="1280" dy="720" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="Use_Cases" value="Use Cases" style="swimlane;html=1;" parent="1" vertex="1">
+          <mxGeometry x="20" y="20" width="300" height="260" as="geometry" />
+        </mxCell>
+        <mxCell id="UC1" value="Browse and filter dog profiles" style="rounded=0;whiteSpace=wrap;html=1;" parent="Use_Cases" vertex="1">
+          <mxGeometry x="20" y="20" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="UC2" value="View dogs with pagination and select favorites" style="rounded=0;whiteSpace=wrap;html=1;" parent="Use_Cases" vertex="1">
+          <mxGeometry x="20" y="50" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="UC3" value="Add or update a dog profile (admin)" style="rounded=0;whiteSpace=wrap;html=1;" parent="Use_Cases" vertex="1">
+          <mxGeometry x="20" y="80" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="UC4" value="Assign or remove dogs for a user" style="rounded=0;whiteSpace=wrap;html=1;" parent="Use_Cases" vertex="1">
+          <mxGeometry x="20" y="110" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="UC5" value="Register a user with tier codes (admin/basic)" style="rounded=0;whiteSpace=wrap;html=1;" parent="Use_Cases" vertex="1">
+          <mxGeometry x="20" y="140" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="UC6" value="Authenticate users" style="rounded=0;whiteSpace=wrap;html=1;" parent="Use_Cases" vertex="1">
+          <mxGeometry x="20" y="170" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="UC7" value="Upload images to Supabase" style="rounded=0;whiteSpace=wrap;html=1;" parent="Use_Cases" vertex="1">
+          <mxGeometry x="20" y="200" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="UC8" value="Submit contact requests" style="rounded=0;whiteSpace=wrap;html=1;" parent="Use_Cases" vertex="1">
+          <mxGeometry x="20" y="230" width="260" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="UC9" value="Retrieve dog data and manage user-dog assignments" style="rounded=0;whiteSpace=wrap;html=1;" parent="Use_Cases" vertex="1">
+          <mxGeometry x="20" y="260" width="260" height="30" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/generate_use_case_drawio.py
+++ b/generate_use_case_drawio.py
@@ -1,0 +1,62 @@
+import xml.etree.ElementTree as ET
+
+# Group definitions: id -> (x, y, width, height)
+groups = {
+    'Use_Cases': (20, 20, 300, 260)
+}
+
+# Nodes: id -> (group_id, x, y, text)
+use_cases = [
+    'Browse and filter dog profiles',
+    'View dogs with pagination and select favorites',
+    'Add or update a dog profile (admin)',
+    'Assign or remove dogs for a user',
+    'Register a user with tier codes (admin/basic)',
+    'Authenticate users',
+    'Upload images to Supabase',
+    'Submit contact requests',
+    'Retrieve dog data and manage user-dog assignments'
+]
+
+nodes = {}
+y = 20
+for i, uc in enumerate(use_cases):
+    nodes[f'UC{i+1}'] = ('Use_Cases', 20, y, uc)
+    y += 30
+
+
+def create_diagram():
+    root = ET.Element('mxfile', host='app.diagrams.net')
+    diagram = ET.SubElement(root, 'diagram', name='Use Cases')
+    model = ET.SubElement(diagram, 'mxGraphModel', dx='1280', dy='720', grid='1',
+                           gridSize='10', guides='1', tooltips='1', connect='1',
+                           arrows='1', fold='1', page='1', pageScale='1',
+                           pageWidth='850', pageHeight='1100', math='0', shadow='0')
+    rt = ET.SubElement(model, 'root')
+    ET.SubElement(rt, 'mxCell', id='0')
+    ET.SubElement(rt, 'mxCell', id='1', parent='0')
+
+    # Add groups
+    for gid, (x, y, w, h) in groups.items():
+        cell = ET.SubElement(rt, 'mxCell', id=gid, value=gid.replace('_', ' '),
+                              style='swimlane;html=1;', parent='1', vertex='1')
+        geom = ET.SubElement(cell, 'mxGeometry', x=str(x), y=str(y),
+                              width=str(w), height=str(h))
+        geom.set('as', 'geometry')
+
+    # Add nodes
+    for nid, (gid, x, y, text) in nodes.items():
+        cell = ET.SubElement(rt, 'mxCell', id=nid, value=text,
+                              style='rounded=0;whiteSpace=wrap;html=1;',
+                              parent=gid, vertex='1')
+        geom = ET.SubElement(cell, 'mxGeometry', x=str(x), y=str(y),
+                              width='260', height='30')
+        geom.set('as', 'geometry')
+
+    ET.indent(root, space="  ")
+    return ET.tostring(root, encoding='utf-8')
+
+if __name__ == '__main__':
+    xml = create_diagram()
+    with open('docs/use_cases.drawio', 'wb') as f:
+        f.write(xml)


### PR DESCRIPTION
## Summary
- add script to generate use case diagram
- generate draw.io file with the primary use cases

## Testing
- `dart test` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e7f52aae88323ac29d777ae5d8ce9