### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/lib/business/theme_provider.dart
+++ b/lib/business/theme_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class ThemeProvider with ChangeNotifier {
+  ThemeMode _themeMode = ThemeMode.dark;
+
+  ThemeMode get themeMode => _themeMode;
+
+  void toggleTheme() {
+    _themeMode = _themeMode == ThemeMode.dark ? ThemeMode.light : ThemeMode.dark;
+    notifyListeners();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:namer_app/business/dog_provider.dart' show DogProvider;
 import 'package:namer_app/business/user_provider.dart';
+import 'package:namer_app/business/theme_provider.dart';
 import 'package:namer_app/screens/dog_human_match_app.dart';
 import 'package:provider/provider.dart';
 
@@ -25,6 +26,7 @@ Future<void> main() async {
       providers: [
         ChangeNotifierProvider(create: (_) => DogProvider()..loadDogs()),
         ChangeNotifierProvider(create: (_) => UserProvider()),
+        ChangeNotifierProvider(create: (_) => ThemeProvider()),
         // Add more providers here if needed
       ],
       child: DogHumanMatchApp(), // ✅ This includes all routes/screens

--- a/lib/screens/dog_human_match_app.dart
+++ b/lib/screens/dog_human_match_app.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:namer_app/router.dart'; // Assuming your router is defined here
+import 'package:provider/provider.dart';
+import 'package:namer_app/business/theme_provider.dart';
 
 class DogHumanMatchApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final themeProvider = Provider.of<ThemeProvider>(context);
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
       title: 'Match Your Pet to You',
@@ -15,7 +18,7 @@ class DogHumanMatchApp extends StatelessWidget {
         brightness: Brightness.dark,
         primarySwatch: Colors.blue,
       ),
-      themeMode: ThemeMode.dark, // Can be .light, .dark, or .system
+      themeMode: themeProvider.themeMode, // Can be .light, .dark, or .system
       routerConfig: router(),
     );
   }

--- a/lib/screens/main_home_page.dart
+++ b/lib/screens/main_home_page.dart
@@ -8,6 +8,7 @@ import 'package:namer_app/screens/login_screen.dart';
 import 'package:namer_app/screens/user_dog_manager_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:namer_app/common/constants.dart';
+import 'package:namer_app/business/theme_provider.dart';
 
 class MainHomePage extends StatelessWidget {
   final String userName;
@@ -194,6 +195,17 @@ class MainHomePage extends StatelessWidget {
                 ),
               );
             },
+          ),
+          Consumer<ThemeProvider>(
+            builder: (context, themeProvider, _) => IconButton(
+              icon: Icon(themeProvider.themeMode == ThemeMode.dark
+                  ? Icons.light_mode
+                  : Icons.dark_mode),
+              tooltip: 'Toggle Theme',
+              onPressed: () {
+                themeProvider.toggleTheme();
+              },
+            ),
           ),
           if (userProvider.userId == null)
             IconButton(


### PR DESCRIPTION
## Summary
- add `ThemeProvider` for controlling app theme
- wire up `ThemeProvider` in `main.dart`
- update `DogHumanMatchApp` to use provided theme
- add theme toggle icon to `MainHomePage`

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580c087764832397d00ee17e3c03af